### PR TITLE
ci: update deploy workflow to v0.0.21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,9 +84,10 @@ jobs:
     if: github.event_name == 'push'
     needs: build
     name: Deploy
-    uses: wajeht/docker-cd-deploy-workflow/.github/workflows/deploy.yaml@c976aac4e51a559837963f7d903600c2c436e589 # v0.0.20
+    uses: wajeht/docker-cd-deploy-workflow/.github/workflows/deploy.yaml@de3f1611b6b8cd6c766ae891f0302b76ce222774 # v0.0.21
     with:
       app-path: apps/commit
+      service-name: commit
       tag: ${{ needs.build.outputs.tag }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Summary

- update docker-cd-deploy-workflow references to v0.0.21
- pass the required service-name input for deploy/temp deploy workflows

## Verification

- workflow YAML parsed locally
- checked no v0.0.20 workflow references remain
