### PR TITLE
feat: use free OpenRouter model by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,11 @@ $ curl -fsSL https://commit.jaw.dev/ | bash
 
 The configuration path follows `$XDG_CONFIG_HOME` when set and defaults to
 `~/.config/commit/config.json`. Set `COMMIT_CONFIG` to use another path. The
-default model is `google/gemini-2.5-flash-lite`. Pass a model ID exactly as
-OpenRouter displays it, for example `openrouter/auto`. Diffs larger than 1 MiB
-are rejected before an API request is made.
+default model is `openrouter/free`, which randomly selects an available free
+model. Free models have lower rate limits and may be less consistent. Pass a
+model ID exactly as OpenRouter displays it, for example `openrouter/auto`, to
+override the default. Diffs larger than 1 MiB are rejected before an API request
+is made.
 
 # Docs
 

--- a/assets/sh/commit.sh
+++ b/assets/sh/commit.sh
@@ -129,7 +129,7 @@ show_help() {
     printf "  ${GREEN}%s${NC}\n" "$CONFIG_FILE"
     printf "  Environment: OPENROUTER_API_KEY, COMMIT_MODEL\n"
     printf "  Model IDs: https://openrouter.ai/models\n"
-    printf "  Default model: google/gemini-2.5-flash-lite\n"
+    printf "  Default model: openrouter/free\n"
     printf "  Maximum diff size: 1 MiB\n"
     printf "\n"
     printf "${YELLOW}Example Usage:${NC}\n"
@@ -238,7 +238,7 @@ setup_config() {
 }
 
 configure_openrouter() {
-    AI_MODEL="${AI_MODEL:-${COMMIT_MODEL:-google/gemini-2.5-flash-lite}}"
+    AI_MODEL="${AI_MODEL:-${COMMIT_MODEL:-openrouter/free}}"
     if [ -z "$API_KEY" ]; then
         API_KEY="${OPENROUTER_API_KEY:-$CONFIG_API_KEY}"
     fi

--- a/assets/templates/index.html
+++ b/assets/templates/index.html
@@ -66,7 +66,10 @@ $ curl -fsSL {{.Domain}} | bash -s -- --model openrouter/auto
 $ curl -fsSL {{.Domain}} | bash -s -- --dry-run
 $ curl -fsSL {{.Domain}} | bash -s -- --yes
 $ curl -fsSL {{.Domain}} | bash -s -- --verbose</code></pre>
-        <p>The default model is <code>google/gemini-2.5-flash-lite</code>.</p>
+        <p>
+            The default is <code>openrouter/free</code>, which randomly selects an available free model.
+            Free models have lower rate limits and may be less consistent.
+        </p>
     </section>
 </article>
 {{end}}

--- a/cmd/script_test.go
+++ b/cmd/script_test.go
@@ -34,7 +34,7 @@ func TestCommitScriptHelpWithArguments(t *testing.T) {
 		"--verbose",
 		"--setup",
 		"https://openrouter.ai/models",
-		"Default model: google/gemini-2.5-flash-lite",
+		"Default model: openrouter/free",
 		"Maximum diff size: 1 MiB",
 		"| bash -s -- --dry-run",
 	} {
@@ -330,7 +330,7 @@ printf '{"choices":[{"message":{"content":"feat: test openrouter"}}]}\n200'
 	if err := json.Unmarshal(requestData, &request); err != nil {
 		t.Fatal(err)
 	}
-	if request.Model != "google/gemini-2.5-flash-lite" {
+	if request.Model != "openrouter/free" {
 		t.Errorf("model = %q", request.Model)
 	}
 	if len(request.Messages) != 2 || !strings.Contains(request.Messages[1].Content, "feature.txt") {

--- a/docs/manual-qa.md
+++ b/docs/manual-qa.md
@@ -77,7 +77,7 @@ Expected:
 
 - OpenRouter returns a one-line Conventional Commit message.
 - The output lists `qa.txt` and does not create a commit.
-- The default request uses `google/gemini-2.5-flash-lite`.
+- The default request uses `openrouter/free`.
 - The key and complete request body are never printed without `--verbose`.
 
 Repeat once with an advanced model override:


### PR DESCRIPTION
## Summary

- make `openrouter/free` the default model
- keep `--model` and `COMMIT_MODEL` overrides unchanged
- document the free router's lower limits and variable consistency

## Why

New users can generate commit messages without paid inference by default.
OpenRouter selects an available free model for each request.

## Validation

- `bash -n assets/sh/commit.sh assets/sh/install.sh`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`
