### PR TITLE
feat: replace Plausible with Umami

### DIFF
--- a/assets/templates/base.html
+++ b/assets/templates/base.html
@@ -6,7 +6,7 @@
     <meta name="robots" content="noindex, nofollow">
     <title>{{.Title}}</title>
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
-    <script defer data-domain="commit.jaw.dev" src="https://plausible.jaw.dev/js/script.js"></script>
+    <script defer src="https://umami.jaw.dev/script.js" data-website-id="523275d2-6964-4ccd-a40f-d6bec6b12c77"></script>
 </head>
 <body>
     <main>


### PR DESCRIPTION
## Summary

- replace the Plausible analytics script with the Umami script
- configure the provided Umami website ID

## Impact

Page analytics will be sent to the self-hosted Umami instance instead of Plausible.

## Validation

- `go test ./...`
- `git diff --check`
